### PR TITLE
refactor/Lap timing

### DIFF
--- a/main.go
+++ b/main.go
@@ -145,67 +145,64 @@ func DataLoggingAtSpecificHertz(w *csv.Writer) {
 	 * - Then work out the seconds and fraction of the `elapsedTime`
 	 * - Then format as desired ("00.0, 00.1, 00.2")
 	 */
-	for {
-		select {
-		case <-ticker.C:
-			// Hertz calculation
-			currentTime := time.Now()
-			elapsed := currentTime.Sub(startTime).Milliseconds()
-			seconds := elapsed / 1000
-			fraction := (elapsed % 1000) / 100
-			time := fmt.Sprintf("%02d.%01d", seconds, fraction)
+	for range ticker.C {
+		// Hertz calculation
+		currentTime := time.Now()
+		elapsed := currentTime.Sub(startTime).Milliseconds()
+		seconds := elapsed / 1000
+		fraction := (elapsed % 1000) / 100
+		time := fmt.Sprintf("%02d.%01d", seconds, fraction)
 
-			var ethanolInput2 string
-			if appSettings.Ecu == "s300" {
-				ethanolInput2 = strconv.FormatFloat(float64(localEthanolInput2S300), 'f', 2, 64)
-			} else {
-				ethanolInput2 = strconv.FormatUint(uint64(localEthanolInput2KPro), 10)
-			}
+		var ethanolInput2 string
+		if appSettings.Ecu == "s300" {
+			ethanolInput2 = strconv.FormatFloat(float64(localEthanolInput2S300), 'f', 2, 64)
+		} else {
+			ethanolInput2 = strconv.FormatUint(uint64(localEthanolInput2KPro), 10)
+		}
 
-			csvFrame := []string{
-				time,
-				strconv.FormatUint(uint64(localRpm), 10),
-				strconv.FormatUint(uint64(localSpeed), 10),
-				strconv.FormatUint(uint64(localGear), 10),
-				strconv.FormatFloat(float64(localVoltage), 'f', 1, 64),
-				strconv.FormatUint(uint64(localIat), 10),
-				strconv.FormatUint(uint64(localEct), 10),
-				strconv.FormatUint(uint64(localMil), 10),
-				strconv.FormatUint(uint64(localVts), 10),
-				strconv.FormatUint(uint64(localCl), 10),
-				strconv.FormatUint(uint64(localTps), 10),
-				strconv.FormatUint(uint64(localMap), 10),
-				strconv.FormatUint(uint64(localInj), 10),
-				strconv.FormatUint(uint64(localIgn), 10),
-				strconv.FormatFloat(float64(localLambdaRatio), 'f', 2, 64),
-				strconv.FormatUint(uint64(localKnockCounter), 10),
-				strconv.FormatFloat(float64(localTargetCamAngle), 'f', 2, 64),
-				strconv.FormatFloat(float64(localActualCamAngle), 'f', 2, 64),
-				strconv.FormatUint(uint64(localAnalog0), 10),
-				strconv.FormatUint(uint64(localAnalog1), 10),
-				strconv.FormatUint(uint64(localAnalog2), 10),
-				strconv.FormatUint(uint64(localAnalog3), 10),
-				strconv.FormatUint(uint64(localAnalog4), 10),
-				strconv.FormatUint(uint64(localAnalog5), 10),
-				strconv.FormatUint(uint64(localAnalog6), 10),
-				strconv.FormatUint(uint64(localAnalog7), 10),
-				strconv.FormatUint(uint64(localEthanolInput1), 10),
-				ethanolInput2,
-				strconv.FormatUint(uint64(localEthanolInput3), 10),
-				strconv.FormatFloat(float64(localLat), 'f', 10, 64),
-				strconv.FormatFloat(float64(localLon), 'f', 10, 64),
-				strconv.FormatUint(uint64(localSessionTimeMs), 10),
-				strconv.FormatUint(uint64(localLapIndex), 10),
-				strconv.FormatUint(uint64(localLapStartTimsMs), 10),
-				// strconv.FormatUint(uint64(localSectorStartTimeMs[0]), 10),
-				// strconv.FormatUint(uint64(localSectorStartTimeMs[1]), 10),
-				// strconv.FormatUint(uint64(localSectorStartTimeMs[2]), 10),
-				// strconv.FormatUint(uint64(localFlags), 10),
-			}
+		csvFrame := []string{
+			time,
+			strconv.FormatUint(uint64(localRpm), 10),
+			strconv.FormatUint(uint64(localSpeed), 10),
+			strconv.FormatUint(uint64(localGear), 10),
+			strconv.FormatFloat(float64(localVoltage), 'f', 1, 64),
+			strconv.FormatUint(uint64(localIat), 10),
+			strconv.FormatUint(uint64(localEct), 10),
+			strconv.FormatUint(uint64(localMil), 10),
+			strconv.FormatUint(uint64(localVts), 10),
+			strconv.FormatUint(uint64(localCl), 10),
+			strconv.FormatUint(uint64(localTps), 10),
+			strconv.FormatUint(uint64(localMap), 10),
+			strconv.FormatUint(uint64(localInj), 10),
+			strconv.FormatUint(uint64(localIgn), 10),
+			strconv.FormatFloat(float64(localLambdaRatio), 'f', 2, 64),
+			strconv.FormatUint(uint64(localKnockCounter), 10),
+			strconv.FormatFloat(float64(localTargetCamAngle), 'f', 2, 64),
+			strconv.FormatFloat(float64(localActualCamAngle), 'f', 2, 64),
+			strconv.FormatUint(uint64(localAnalog0), 10),
+			strconv.FormatUint(uint64(localAnalog1), 10),
+			strconv.FormatUint(uint64(localAnalog2), 10),
+			strconv.FormatUint(uint64(localAnalog3), 10),
+			strconv.FormatUint(uint64(localAnalog4), 10),
+			strconv.FormatUint(uint64(localAnalog5), 10),
+			strconv.FormatUint(uint64(localAnalog6), 10),
+			strconv.FormatUint(uint64(localAnalog7), 10),
+			strconv.FormatUint(uint64(localEthanolInput1), 10),
+			ethanolInput2,
+			strconv.FormatUint(uint64(localEthanolInput3), 10),
+			strconv.FormatFloat(float64(localLat), 'f', 10, 64),
+			strconv.FormatFloat(float64(localLon), 'f', 10, 64),
+			strconv.FormatUint(uint64(localSessionTimeMs), 10),
+			strconv.FormatUint(uint64(localLapIndex), 10),
+			strconv.FormatUint(uint64(localLapStartTimsMs), 10),
+			// strconv.FormatUint(uint64(localSectorStartTimeMs[0]), 10),
+			// strconv.FormatUint(uint64(localSectorStartTimeMs[1]), 10),
+			// strconv.FormatUint(uint64(localSectorStartTimeMs[2]), 10),
+			// strconv.FormatUint(uint64(localFlags), 10),
+		}
 
-			if err := w.Write(csvFrame); err != nil {
-				log.Fatalln("Error writing data to CSV", err)
-			}
+		if err := w.Write(csvFrame); err != nil {
+			log.Fatalln("Error writing data to CSV", err)
 		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -20,20 +20,21 @@ import (
 	"go.einride.tech/can/pkg/socketcan"
 )
 
-// --- MISC ---
-const SETTINGSFILEPATH = "wt-app-settings.json"
+const (
+	// --- MISC ---
+	SETTINGSFILEPATH = "wt-app-settings.json"
 
-// --- Data conversion constants ---
-// Oil Temp
-const OILTEMP_A = 0.0014222095
-const OILTEMP_B = 0.00023729017
-const OILTEMP_C = 9.3273998e-8
-
-// Oil Pressure
-const OILPRESSURE_originalLow float64 = 0    //0.5
-const OILPRESSURE_originalHigh float64 = 5   //4.5
-const OILPRESSURE_desiredLow float64 = -100  //0
-const OILPRESSURE_desiredHigh float64 = 1100 //1000
+	// --- Data conversion constants ---
+	// Oil Temp
+	OILTEMP_A = 0.0014222095
+	OILTEMP_B = 0.00023729017
+	OILTEMP_C = 9.3273998e-8
+	// Oil Pressure
+	OILPRESSURE_originalLow float64 = 0    //0.5
+	OILPRESSURE_originalHigh float64 = 5   //4.5
+	OILPRESSURE_desiredLow float64 = -100  //0
+	OILPRESSURE_desiredHigh float64 = 1100 //1000
+)
 
 type AppSettings struct {
 	LoggingHertz int    `json:"loggingHertz"`

--- a/main.go
+++ b/main.go
@@ -402,6 +402,7 @@ func main() {
 	// -------------------- Read CAN and write to file --------------------
 	conn, _ := socketcan.DialContext(context.Background(), "can", appSettings.CanChannel)
 	defer conn.Close()
+
 	recv := socketcan.NewReceiver(conn)
 
 	// Do datalogging

--- a/main.go
+++ b/main.go
@@ -102,7 +102,7 @@ var (
 	// localFlags             uint8
 
 	gpsData = GpsData{}
-	lapTiming = LapTiming{ LapIndex: 0, Flags: 0}
+	lapTiming = LapTiming{ LapIndex: 0 }
 )
 
 func DataLoggingAtSpecificHertz(w *csv.Writer) {
@@ -281,7 +281,7 @@ func handleLapTiming() {
 	// gps.Close()
 }
 
-func handleGpsDatalogging() {
+func handleLapTimingOld() {
 	var gps *gpsd.Session
 	var err error
 

--- a/main.go
+++ b/main.go
@@ -442,9 +442,7 @@ func main() {
 
 		case 662, 1634:
 			localTps = binary.BigEndian.Uint16(frame.Data[0:2])
-			if localTps == 65535 {
-				localTps = 0
-			}
+			if localTps > 65000 { localTps = 0 }
 			localMap = binary.BigEndian.Uint16(frame.Data[2:4]) / 10
 
 		case 663, 1635:
@@ -452,7 +450,8 @@ func main() {
 			localIgn = binary.BigEndian.Uint16(frame.Data[2:4])
 
 		case 664, 1636:
-			localLambdaRatio = math.Round(float64(32768.0)/float64(binary.BigEndian.Uint16(frame.Data[0:2]))*100) / 100
+			localLambdaRatio = math.Round(float64(32768.0)/float64(binary.BigEndian.Uint16(frame.Data[0:2])) * 100) / 100
+			if math.IsInf(localLambdaRatio, 0) { localLambdaRatio = 0 }
 
 		// K-Pro only
 		case 665, 1637:
@@ -472,11 +471,14 @@ func main() {
 			oilTempResistance := binary.BigEndian.Uint16(frame.Data[0:2])
 			kelvinTemp := 1 / (OILTEMP_A + OILTEMP_B * math.Log(float64(oilTempResistance)) + OILTEMP_C * math.Pow(math.Log(float64(oilTempResistance)), 3))
 			localAnalog0 = uint16(kelvinTemp - 273.15)
+			if localAnalog0 > 65000 { localAnalog0 = 0}
 
 			// Oil Pressure
 			oilPressureResistance := float64(binary.BigEndian.Uint16(frame.Data[2:4])) / 819.2
 			kPaValue := ((float64(oilPressureResistance) - OILPRESSURE_originalLow) / (OILPRESSURE_originalHigh - OILPRESSURE_originalLow) * (OILPRESSURE_desiredHigh - OILPRESSURE_desiredLow)) + OILPRESSURE_desiredLow
 			localAnalog1 = uint16(math.Round(kPaValue * 0.145038)) // Convert to psi
+			if localAnalog1 > 65000 { localAnalog1 = 0}
+
 			localAnalog2 = binary.BigEndian.Uint16(frame.Data[4:6])
 			localAnalog3 = binary.BigEndian.Uint16(frame.Data[6:8])
 

--- a/main.go
+++ b/main.go
@@ -45,12 +45,9 @@ type AppSettings struct {
 	LapTiming    bool   `json:"lapTiming"`
 }
 
-type GpsData struct {
+type LapTiming struct {
 	PreviousLat float64
 	PreviousLon float64
-}
-
-type LapTiming struct {
 	SessionTimeMs     uint32   // absolute session time in ms, safe up to 49 days
 	LapIndex          uint16   // lap counter, safe up to 65k laps
 	LapStartTimeMs    uint32   // absolute session time at last lap start
@@ -100,7 +97,6 @@ var (
 	// localSectorStartTimeMs []uint32
 	// localFlags             uint8
 
-	gpsData = GpsData{}
 	lapTiming = LapTiming{ LapIndex: 0 }
 )
 
@@ -253,15 +249,15 @@ func handleLapTimingNew() {
 	tpvFilter := func(r interface{}) {
 		report := r.(*gpsd.TPVReport)
 
-		if isThisTheFinishLine(gpsData.PreviousLat, gpsData.PreviousLon, report.Lat, report.Lon) {
+		if isThisTheFinishLine(lapTiming.PreviousLat, lapTiming.PreviousLon, report.Lat, report.Lon) {
 			lapTiming.LapStartTimeMs = lapTiming.SessionTimeMs
 			lapTiming.LapIndex++
 			localLapStartTimsMs = lapTiming.LapStartTimeMs
 			localLapIndex = lapTiming.LapIndex
 		}
 
-		gpsData.PreviousLat = report.Lat
-		gpsData.PreviousLon = report.Lon
+		lapTiming.PreviousLat = report.Lat
+		lapTiming.PreviousLon = report.Lon
 		localLat = report.Lat
 		localLon = report.Lon
 	}
@@ -311,15 +307,15 @@ func handleLapTimingOld() {
 		lapTiming.SessionTimeMs = uint32(timeDiff.Milliseconds())
 		
 
-		if isThisTheFinishLine(gpsData.PreviousLat, gpsData.PreviousLon, report.Lat, report.Lon) {
+		if isThisTheFinishLine(lapTiming.PreviousLat, lapTiming.PreviousLon, report.Lat, report.Lon) {
 			lapTiming.LapStartTimeMs = lapTiming.SessionTimeMs
 			lapTiming.LapIndex++
 			localLapStartTimsMs = lapTiming.LapStartTimeMs
 			localLapIndex = lapTiming.LapIndex
 		}
 
-		gpsData.PreviousLat = report.Lat
-		gpsData.PreviousLon = report.Lon
+		lapTiming.PreviousLat = report.Lat
+		lapTiming.PreviousLon = report.Lon
 		localLat = report.Lat
 		localLon = report.Lon
 	}

--- a/main.go
+++ b/main.go
@@ -400,7 +400,10 @@ func main() {
 	defer writer.Flush()
 
 	// -------------------- Read CAN and write to file --------------------
-	conn, _ := socketcan.DialContext(context.Background(), "can", appSettings.CanChannel)
+	conn, err := socketcan.DialContext(context.Background(), "can", appSettings.CanChannel)
+	if err != nil {
+		log.Fatal("[ERROR] Cannot connect to CAN channel: ", appSettings.CanChannel)
+	}
 	defer conn.Close()
 
 	recv := socketcan.NewReceiver(conn)


### PR DESCRIPTION
Refactor the lap timing with how we send through the GPS data and timing data from client, instead of sending all lap data we only send an overall session time, lap index and lap time as the raw data. The derived data like current lap, best lap, pb lap etc is calculated on the go.

Also a bunch of refactoring, tidying up etc